### PR TITLE
Ensure the auto-installer also copies the newly added flag

### DIFF
--- a/install.py
+++ b/install.py
@@ -553,6 +553,7 @@ class ExfoliationInstaller(ExtensionInstaller):
                                                 			'skins/Weather34/img/flags/ar.svg',
                                                 			'skins/Weather34/img/flags/aus.svg',
                                                 			'skins/Weather34/img/flags/b.svg',
+                                                                        'skins/Weather34/img/flags/be.svg',
                                                 			'skins/Weather34/img/flags/c.svg',
                                                 			'skins/Weather34/img/flags/can.svg',
                                                 			'skins/Weather34/img/flags/cat.svg',


### PR DESCRIPTION
This line was missing from the installer, I forgot to add it in the earlier pull request.