### PR TITLE
A few quick patches

### DIFF
--- a/skins/Weather34/archivedata.php.tmpl
+++ b/skins/Weather34/archivedata.php.tmpl
@@ -142,10 +142,17 @@ $weewxapi[70] = "$span(time_delta=900).inTemp.avg.format(add_label=False, $local
 $weewxapi[71] = "$span(time_delta=900).inHumidity.avg.format(add_label=False, $localize=False)";
 $weewxapi[72] = "$span($time_delta=900).windSpeed.avg.format(add_label=False, $localize=False)";
 $weewxapi[73] = "$span($time_delta=1800).windSpeed.avg.format(add_label=False, $localize=False)";
+#if $varExists('month.lightning_strike_count.sum')
 $weewxapi[74] = "$month.lightning_strike_count.sum.format(add_label=False, $localize=False)";	
 $weewxapi[75] = "$year.lightning_strike_count.sum.format(add_label=False, $localize=False)";	
 $weewxapi[76] = "$day.lightning_strike_count.sum.format(add_label=False, $localize=False)";	
 $weewxapi[77] = "$year.lightning_distance.lasttime.format(format_string="%Y-%m-%d %H:%M:%S")";
+#else
+$weewxapi[74] = "";
+$weewxapi[75] = "";
+$weewxapi[76] = "";
+$weewxapi[77] = "";
+#end if
 $weewxapi[78] = "N/A";	
 $weewxapi[79] = "N/A";
 $weewxapi[80] = "$day.radiation.max.format(add_label=False, $localize=False)";

--- a/www/currentconditionsw34.php
+++ b/www/currentconditionsw34.php
@@ -137,8 +137,10 @@ else if($weather["cloud_cover"]<=100) {$weather["cloud_oktas"]="8 oktas";}
 <div class="darkskynexthours">
 <?php //weather34 average station data
 //echo "Average <oblue>Cloud Cover</oblue> last 5 minutes <ogreen>" .$weather["cloud_cover"]."</ogreen><valuetext>".$cloudcoverunit. "(".$weather["cloud_oktas"].")";
-echo "<oblue>Cloud Cover</oblue><ogreen> " .$weather["cloud_cover"]."</ogreen><valuetext>".$cloudcoverunit. " (".$weather["cloud_oktas"].")";
-echo "<br>Average <oorange>Temperature</oorange> last 60 minutes ";if($weather["temp_avg"]>=20){echo "<oorange>" .$weather["temp_avg"]."</oorange>°<valuetext>".$tempunit;} else if($weather["temp_avg"]<=10){echo "<oblue>" .$weather["temp_avg"]."</oblue>°<valuetext>".$tempunit;}else if($weather["temp_avg"]<20){echo "<ogreen>" .$weather["temp_avg"]."</ogreen>°<valuetext>".$tempunit;}echo "</valuetext><br>";
+if($weather["cloud_cover"]!="?'signal8'?") {
+  echo "<oblue>Cloud Cover</oblue><ogreen> " .$weather["cloud_cover"]."</ogreen><valuetext>".$cloudcoverunit. " (".$weather["cloud_oktas"].")<br>";
+}
+echo "Average <oorange>Temperature</oorange> last 60 minutes ";if($weather["temp_avg"]>=20){echo "<oorange>" .$weather["temp_avg"]."</oorange>°<valuetext>".$tempunit;} else if($weather["temp_avg"]<=10){echo "<oblue>" .$weather["temp_avg"]."</oblue>°<valuetext>".$tempunit;}else if($weather["temp_avg"]<20){echo "<ogreen>" .$weather["temp_avg"]."</ogreen>°<valuetext>".$tempunit;}echo "</valuetext><br>";
 echo  "Max <oblue>Wind Gust</oblue> ";
 if ($windunit=='kts'){$windunit="kn";}
 //if ($windunit=='kn'){$weather["wind_gust_60min"] = number_format(1.94384*$weather["wind_gust_60min"], 1);}

--- a/www/easyW34skinSetup.php
+++ b/www/easyW34skinSetup.php
@@ -2587,7 +2587,7 @@ double check again
   </div>        
   <input id="pu_url" type="hidden" name="pu_url" value="https://www.purpleair.com/json?show=$purpleairID"/><br/>
   </div>
-  <input id="pu_filename" type="hidden" name="pu_filename" value="purpleair.txt"/><br/>
+  <input id="pu_filename" type="hidden" name="pu_filename" value="$jsondatapath/purpleair.txt"/><br/>
   </div>
   <input id="continent" type="hidden" name="continent" value="eu"/><br/>
   </div>


### PR DESCRIPTION
Three quick patches to support the original wview schema, handle when CloudCover isn't enabled, and fix purpleair path in the easysetup.

archivedata.php.tmpl creates corrupt archivedata.php files when
schema not wview_extended (file contains un-escaped %).  Fix is to
check for exteneded schema, and output blank fields if basic schema.

If CloudCover is not enabled, current.signal8 has an unknown type.
Fix is to check for the error text before the value is used (useful
when running wee_reports too).

easysetup was setting the purpleair.txt filename without the
jsondatapath, breaking the service updates.