### PR TITLE
Restoring style for cursor

### DIFF
--- a/www/css/main.dark.css
+++ b/www/css/main.dark.css
@@ -190,8 +190,11 @@ body {
   clear: both;
   font-size: 14px;
   line-height: 1.42857143;
-  cursor: url(mouse/weather34redcursor.png), n-resize;
   color: silver
+}
+
+body.dotpointercursor {
+  cursor: url(mouse/weather34redcursor.png), n-resize;
 }
 
 .menu {
@@ -5169,7 +5172,7 @@ smallrainunit {
   justify-content: center;
   border: 1px solid #38383c;
   border-radius: 2px;
-  font-size: .85em  
+  font-size: .85em
 }
 
 .barometerconverter,
@@ -7095,7 +7098,7 @@ rainratetextheading {
   border-left: 0;
   box-shadow: inset 4px 0 0 0 #e26870;
   border-top-right-radius: 2px;
-  border-bottom-right-radius: 2px
+  border-bottom-right-radius: 2px;
   font-weight: 400
 }
 

--- a/www/css/main.light.css
+++ b/www/css/main.light.css
@@ -207,6 +207,9 @@ html {
 body {
   background: #fff;
   clear: both;
+}
+
+body.dotpointercursor {
   cursor: url(mouse/weather34bluecursor.png), n-resize
 }
 

--- a/www/css/wuoutlook.css
+++ b/www/css/wuoutlook.css
@@ -217,7 +217,7 @@ purpleu {
 }
 
 .darkskyforecasthome darkskytemphihome span {
-  font-size: : .7rem;
+  font-size: .7rem;
   color: #ff7c39;
   font-family: Arial;
   line-height: 10px


### PR DESCRIPTION
Restoring CSS style for cursor implementation mistakenly removed on commits:

https://github.com/steepleian/weewx-Weather34/commit/2363eb4f49da1198f29bf0d434f9eefaca83faad
https://github.com/steepleian/weewx-Weather34/commit/5c4d7e69147685a038e882d980672b61bd0bf857