### PR TITLE
Restoring style for cursor

### DIFF
--- a/www/css/main.dark.css
+++ b/www/css/main.dark.css
@@ -190,8 +190,11 @@ body {
   clear: both;
   font-size: 14px;
   line-height: 1.42857143;
-  cursor: url(mouse/weather34redcursor.png), n-resize;
   color: silver
+}
+
+body.dotpointercursor {
+  cursor: url(mouse/weather34redcursor.png), n-resize;
 }
 
 .menu {
@@ -5169,7 +5172,7 @@ smallrainunit {
   justify-content: center;
   border: 1px solid #38383c;
   border-radius: 2px;
-  font-size: .85em  
+  font-size: .85em
 }
 
 .barometerconverter,
@@ -7095,7 +7098,7 @@ rainratetextheading {
   border-left: 0;
   box-shadow: inset 4px 0 0 0 #e26870;
   border-top-right-radius: 2px;
-  border-bottom-right-radius: 2px
+  border-bottom-right-radius: 2px;
   font-weight: 400
 }
 

--- a/www/css/main.light.css
+++ b/www/css/main.light.css
@@ -207,6 +207,9 @@ html {
 body {
   background: #fff;
   clear: both;
+}
+
+body.dotpointercursor {
   cursor: url(mouse/weather34bluecursor.png), n-resize
 }
 


### PR DESCRIPTION
Restoring CSS style for cursor implementation mistakenly removed on commits:

steepleian@2363eb4
steepleian@5c4d7e6