### PR TITLE
Restoring style for cursor

### DIFF
--- a/www/css/main.dark.css
+++ b/www/css/main.dark.css
@@ -192,9 +192,11 @@ body {
   line-height: 1.42857143;
   color: silver
 }
+
 body.dotpointercursor {
   cursor: url(mouse/weather34redcursor.png), n-resize;
 }
+
 .menu {
   width: 220px;
   margin: 0;
@@ -5170,7 +5172,7 @@ smallrainunit {
   justify-content: center;
   border: 1px solid #38383c;
   border-radius: 2px;
-  font-size: .85em  
+  font-size: .85em
 }
 
 .barometerconverter,
@@ -7096,7 +7098,7 @@ rainratetextheading {
   border-left: 0;
   box-shadow: inset 4px 0 0 0 #e26870;
   border-top-right-radius: 2px;
-  border-bottom-right-radius: 2px
+  border-bottom-right-radius: 2px;
   font-weight: 400
 }
 

--- a/www/css/main.light.css
+++ b/www/css/main.light.css
@@ -207,7 +207,10 @@ html {
 body {
   background: #fff;
   clear: both;
- cursor: url(mouse/weather34bluecursor.png), n-resize;
+}
+
+body.dotpointercursor {
+  cursor: url(mouse/weather34bluecursor.png), n-resize
 }
 
 #navigation {


### PR DESCRIPTION
Restoring CSS style for cursor implementation mistakenly removed on commits:

steepleian@2363eb4
steepleian@5c4d7e6